### PR TITLE
로그인 api 경로수정

### DIFF
--- a/src/main/java/com/depromeet/deprocheck/deprocheckapi/domain/service/LoginService.java
+++ b/src/main/java/com/depromeet/deprocheck/deprocheckapi/domain/service/LoginService.java
@@ -1,10 +1,5 @@
 package com.depromeet.deprocheck.deprocheckapi.domain.service;
 
-import com.depromeet.deprocheck.deprocheckapi.domain.Member;
-import com.depromeet.deprocheck.deprocheckapi.domain.vo.LoginValue;
-
 public interface LoginService {
-    Member login(LoginValue loginValue);
-
     String login(String name);
 }

--- a/src/main/java/com/depromeet/deprocheck/deprocheckapi/domain/service/LoginService.java
+++ b/src/main/java/com/depromeet/deprocheck/deprocheckapi/domain/service/LoginService.java
@@ -5,4 +5,6 @@ import com.depromeet.deprocheck.deprocheckapi.domain.vo.LoginValue;
 
 public interface LoginService {
     Member login(LoginValue loginValue);
+
+    String login(String name);
 }

--- a/src/main/java/com/depromeet/deprocheck/deprocheckapi/domain/service/impl/LoginServiceImpl.java
+++ b/src/main/java/com/depromeet/deprocheck/deprocheckapi/domain/service/impl/LoginServiceImpl.java
@@ -5,12 +5,10 @@ import com.depromeet.deprocheck.deprocheckapi.domain.Member;
 import com.depromeet.deprocheck.deprocheckapi.domain.exception.UnauthorizedException;
 import com.depromeet.deprocheck.deprocheckapi.domain.repository.MemberRepository;
 import com.depromeet.deprocheck.deprocheckapi.domain.service.LoginService;
-import com.depromeet.deprocheck.deprocheckapi.domain.vo.LoginValue;
 import com.depromeet.deprocheck.deprocheckapi.infrastructure.auth.JwtFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.Assert;
 
 @Service
 @RequiredArgsConstructor
@@ -18,24 +16,6 @@ public class LoginServiceImpl implements LoginService {
 
     private final MemberRepository memberRepository;
     private final JwtFactory jwtFactory;
-
-    @Override
-    @Transactional
-    public Member login(LoginValue loginValue) {
-        Assert.notNull(loginValue, "'loginValue' must not be null");
-
-        Authority authority = loginValue.getAuthority();
-        switch (authority) {
-            case ADMIN:
-                return loginAdmin(loginValue.getName());
-            case MEMBER:
-                return loginMember(loginValue.getName());
-            case LEAVER:
-            case UNKNOWN:
-            default:
-                throw new IllegalArgumentException("'authority' is not supported. authority:" + authority);
-        }
-    }
 
     @Override
     @Transactional(readOnly = true)

--- a/src/main/java/com/depromeet/deprocheck/deprocheckapi/infrastructure/auth/JwtFactory.java
+++ b/src/main/java/com/depromeet/deprocheck/deprocheckapi/infrastructure/auth/JwtFactory.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @Slf4j
 @RequiredArgsConstructor
 public class JwtFactory {
-    private static final String NAME = "name";
+    private static final String MEMBER_ID = "memberId";
     private static final String HEADER_PREFIX = "Bearer ";
 
     private final JWTVerifier jwtVerifier;
@@ -26,12 +26,12 @@ public class JwtFactory {
     /**
      * jwt 를 생성합니다.
      */
-    public String generateToken(String name) {
+    public String generateToken(Integer memberId) {
         String token;
 
         token = JWT.create()
                 .withIssuer(tokenIssuer)
-                .withClaim(NAME, name)
+                .withClaim(MEMBER_ID, memberId)
                 .sign(Algorithm.HMAC256(tokenSigningKey));
         log.info("token -- " + token);
         return token;
@@ -64,12 +64,12 @@ public class JwtFactory {
         }
 
         Map<String, Claim> claims = decodedJWT.getClaims();
-        Claim idClaim = claims.get(NAME);
+        Claim idClaim = claims.get(MEMBER_ID);
         if (idClaim == null) {
             log.warn("Failed to decode jwt token. header:" + header);
             return Optional.empty();
         }
-        return Optional.of(idClaim.asInt());
+        return Optional.ofNullable(idClaim.asInt());
     }
 
     private String extractToken(String header) {

--- a/src/main/java/com/depromeet/deprocheck/deprocheckapi/infrastructure/auth/JwtFactory.java
+++ b/src/main/java/com/depromeet/deprocheck/deprocheckapi/infrastructure/auth/JwtFactory.java
@@ -79,7 +79,7 @@ public class JwtFactory {
         if (header.length() < HEADER_PREFIX.length()) {
             throw new IllegalArgumentException("Authorization header size가 옳지 않습니다. header의 길이는 " + HEADER_PREFIX.length() + " 보다 크거나 같아야 합니다.");
         }
-        if (!header.startsWith(HEADER_PREFIX)) {
+        if (!HEADER_PREFIX.equalsIgnoreCase(header.substring(0, HEADER_PREFIX.length()))) {
             throw new IllegalArgumentException("올바른 header 형식이 아닙니다. " + HEADER_PREFIX + "로 시작해야 합니다. ");
         }
         return header.substring(HEADER_PREFIX.length());

--- a/src/main/java/com/depromeet/deprocheck/deprocheckapi/infrastructure/config/WebMvcConfig.java
+++ b/src/main/java/com/depromeet/deprocheck/deprocheckapi/infrastructure/config/WebMvcConfig.java
@@ -21,10 +21,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 // health check
                 .excludePathPatterns("/api/monitor/l7check")
                 // login
-                .excludePathPatterns(
-                        "/api/members/login",
-                        "/api/admin/login"
-                );
+                .excludePathPatterns("/api/login");
     }
 
     @Override

--- a/src/main/java/com/depromeet/deprocheck/deprocheckapi/ui/controller/AdminController.java
+++ b/src/main/java/com/depromeet/deprocheck/deprocheckapi/ui/controller/AdminController.java
@@ -5,12 +5,12 @@ import com.depromeet.deprocheck.deprocheckapi.domain.Authority;
 import com.depromeet.deprocheck.deprocheckapi.domain.Member;
 import com.depromeet.deprocheck.deprocheckapi.domain.Session;
 import com.depromeet.deprocheck.deprocheckapi.domain.exception.UnauthorizedException;
-import com.depromeet.deprocheck.deprocheckapi.domain.service.LoginService;
 import com.depromeet.deprocheck.deprocheckapi.domain.service.MemberService;
 import com.depromeet.deprocheck.deprocheckapi.domain.service.SessionService;
-import com.depromeet.deprocheck.deprocheckapi.domain.vo.LoginValue;
-import com.depromeet.deprocheck.deprocheckapi.infrastructure.auth.JwtFactory;
-import com.depromeet.deprocheck.deprocheckapi.ui.dto.*;
+import com.depromeet.deprocheck.deprocheckapi.ui.dto.MemberCreateRequest;
+import com.depromeet.deprocheck.deprocheckapi.ui.dto.MemberResponse;
+import com.depromeet.deprocheck.deprocheckapi.ui.dto.SessionCreateRequest;
+import com.depromeet.deprocheck.deprocheckapi.ui.dto.SessionResponse;
 import com.depromeet.deprocheck.deprocheckapi.ui.dto.admin.AdminAttendanceResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -39,31 +39,8 @@ import java.util.stream.Collectors;
 public class AdminController {
 
     private final MemberService memberService;
-    private final LoginService loginService;
     private final SessionService sessionService;
-    private final JwtFactory jwtFactory;
     private final MemberAssembler memberAssembler;
-
-    /**
-     * 관리자 로그인 (이름 필드에 특정 비밀번호를 저장합니다)
-     */
-    @ApiOperation("멤버 이름을 입력해서 로그인합니다. 인증이 필요하지 않은 요청입니다. ")
-    @PostMapping("/login")
-    public LoginResponse login(@RequestBody LoginRequest loginRequest,
-                               HttpServletRequest request) {
-        final String adminName = (String) request.getAttribute("name");
-        if (!StringUtils.isEmpty(adminName)) {
-            String accessToken = jwtFactory.generateToken(adminName);
-            return LoginResponse.from(accessToken);
-        }
-        final LoginValue loginValue = LoginValue.of(
-                loginRequest.getName(),
-                Authority.ADMIN
-        );
-        final Member member = loginService.login(loginValue);
-        String accessToken = jwtFactory.generateToken(member.getName());
-        return LoginResponse.from(accessToken);
-    }
 
     /**
      * 세션 정보를 생성합니다

--- a/src/main/java/com/depromeet/deprocheck/deprocheckapi/ui/controller/LoginController.java
+++ b/src/main/java/com/depromeet/deprocheck/deprocheckapi/ui/controller/LoginController.java
@@ -1,0 +1,28 @@
+package com.depromeet.deprocheck.deprocheckapi.ui.controller;
+
+import com.depromeet.deprocheck.deprocheckapi.domain.service.LoginService;
+import com.depromeet.deprocheck.deprocheckapi.ui.dto.LoginRequest;
+import com.depromeet.deprocheck.deprocheckapi.ui.dto.LoginResponse;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Api(value = "로그인", description = "멤버 관련 요청입니다. 인증이 필요하지 않습니다.")
+@CrossOrigin(origins = {
+        "http://localhost:3000",
+        "https://check.depromeet.com"
+})
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class LoginController {
+    private final LoginService loginService;
+
+    @ApiOperation("멤버 이름을 입력해서 로그인합니다. 인증이 필요하지 않은 요청입니다. 회원 권한에 관계없이 모두 사용 가능합니다. 이미 로그인되어있는 경우에도, 새 로그인 정보에 맞는 토큰을 발급합니다. ")
+    @PostMapping("/login")
+    public LoginResponse login(@RequestBody LoginRequest loginRequest) {
+        String accessToken = loginService.login(loginRequest.getName());
+        return LoginResponse.from(accessToken);
+    }
+}

--- a/src/main/java/com/depromeet/deprocheck/deprocheckapi/ui/controller/MemberController.java
+++ b/src/main/java/com/depromeet/deprocheck/deprocheckapi/ui/controller/MemberController.java
@@ -2,20 +2,14 @@ package com.depromeet.deprocheck.deprocheckapi.ui.controller;
 
 import com.depromeet.deprocheck.deprocheckapi.application.assembler.MemberAssembler;
 import com.depromeet.deprocheck.deprocheckapi.domain.Attendance;
-import com.depromeet.deprocheck.deprocheckapi.domain.Authority;
 import com.depromeet.deprocheck.deprocheckapi.domain.Member;
 import com.depromeet.deprocheck.deprocheckapi.domain.Session;
 import com.depromeet.deprocheck.deprocheckapi.domain.exception.BadRequestException;
 import com.depromeet.deprocheck.deprocheckapi.domain.exception.UnauthorizedException;
 import com.depromeet.deprocheck.deprocheckapi.domain.service.AttendanceService;
-import com.depromeet.deprocheck.deprocheckapi.domain.service.LoginService;
 import com.depromeet.deprocheck.deprocheckapi.domain.service.MemberService;
 import com.depromeet.deprocheck.deprocheckapi.domain.service.SessionService;
 import com.depromeet.deprocheck.deprocheckapi.domain.vo.AttendanceValue;
-import com.depromeet.deprocheck.deprocheckapi.domain.vo.LoginValue;
-import com.depromeet.deprocheck.deprocheckapi.infrastructure.auth.JwtFactory;
-import com.depromeet.deprocheck.deprocheckapi.ui.dto.LoginRequest;
-import com.depromeet.deprocheck.deprocheckapi.ui.dto.LoginResponse;
 import com.depromeet.deprocheck.deprocheckapi.ui.dto.MemberAttendRequest;
 import com.depromeet.deprocheck.deprocheckapi.ui.dto.MemberResponse;
 import com.depromeet.deprocheck.deprocheckapi.ui.dto.member.MemberAttendanceResponse;
@@ -42,27 +36,7 @@ public class MemberController {
     private final AttendanceService attendanceService;
     private final MemberService memberService;
     private final SessionService sessionService;
-    private final LoginService loginService;
-    private final JwtFactory jwtFactory;
     private final MemberAssembler memberAssembler;
-
-    @ApiOperation("멤버 이름을 입력해서 로그인합니다. 인증이 필요하지 않은 요청입니다.")
-    @PostMapping("/members/login")
-    public LoginResponse loginMember(@RequestBody LoginRequest loginRequest,
-                                     HttpServletRequest request) {
-        String memberName = (String) request.getAttribute("name");
-        if (!StringUtils.isEmpty(memberName)) {
-            String accessToken = jwtFactory.generateToken(memberName);
-            return LoginResponse.from(accessToken);
-        }
-        LoginValue loginValue = LoginValue.of(
-                loginRequest.getName(),
-                Authority.MEMBER
-        );
-        Member member = loginService.login(loginValue);
-        String accessToken = jwtFactory.generateToken(member.getName());
-        return LoginResponse.from(accessToken);
-    }
 
     @ApiOperation("자기 자신의 정보를 조회합니다.")
     @GetMapping("/members/me")

--- a/src/main/java/com/depromeet/deprocheck/deprocheckapi/ui/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/depromeet/deprocheck/deprocheckapi/ui/interceptor/AuthInterceptor.java
@@ -15,14 +15,14 @@ import javax.servlet.http.HttpServletResponse;
 public class AuthInterceptor extends HandlerInterceptorAdapter {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String ID = "id";
+    private static final String MEMBER_ID = "memberId";
     private final AuthorizationService authorizationService;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String header = request.getHeader(AUTHORIZATION_HEADER);
         AuthorizationResult result = authorizationService.authorize(header);
-        request.setAttribute(ID, result.getId());
+        request.setAttribute(MEMBER_ID, result.getId());
         return super.preHandle(request, response, handler);
     }
 }

--- a/src/test/java/com/depromeet/deprocheck/deprocheckapi/ui/controller/AdminControllerTest.java
+++ b/src/test/java/com/depromeet/deprocheck/deprocheckapi/ui/controller/AdminControllerTest.java
@@ -64,7 +64,7 @@ public class AdminControllerTest {
         // given
         // when
         LoginRequest loginRequest = TestHelper.createLoginRequest("디프만");
-        mockMvc.perform(post("/api/admin/login")
+        mockMvc.perform(post("/api/login")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .content(objectMapper.writeValueAsString(loginRequest)))
                 // then

--- a/src/test/java/com/depromeet/deprocheck/deprocheckapi/ui/controller/MemberControllerTest.java
+++ b/src/test/java/com/depromeet/deprocheck/deprocheckapi/ui/controller/MemberControllerTest.java
@@ -46,7 +46,7 @@ public class MemberControllerTest {
         memberRepository.save(member);
         // when
         LoginRequest loginRequest = TestHelper.createLoginRequest(MEMBER_NAME);
-        mockMvc.perform(post("/api/members/login")
+        mockMvc.perform(post("/api/login")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
                 .content(objectMapper.writeValueAsString(loginRequest)))
                 // then


### PR DESCRIPTION
- 로그인 endpoint 를 변경합니다
- token 에 이름 대신 memberId 를 저장합니다
- `bearer` 키워드의 대소문자를 구분하지 않습니다. 